### PR TITLE
Conflict resolution

### DIFF
--- a/aboutus/css/index.css
+++ b/aboutus/css/index.css
@@ -33,7 +33,7 @@ body {
   color: rgba(57, 61, 68, 1);
   line-height: 34px;
   text-align: left;
-
+  width:100%;
   margin: 28px 8px;
 }
 
@@ -44,7 +44,7 @@ body {
   color: rgba(57, 61, 68, 1);
   line-height: 34px;
   text-align: left;
-
+  width:100%;
   margin: 28px 8px;
 }
 
@@ -56,6 +56,7 @@ body {
   line-height: 34px;
   text-align: left;
   margin: 28px 8px;
+  width:100%;
 }
 
 .content-1 li:nth-of-type(4) {

--- a/members/css/index.css
+++ b/members/css/index.css
@@ -108,4 +108,5 @@
   border: 0;
   color: #6AA666;
   cursor: pointer;
+  background:transparent;
 }

--- a/news/volunteer/body.html
+++ b/news/volunteer/body.html
@@ -42,7 +42,7 @@
                                 {{#description}}
                                 <div class="volunteer_description">
                                     <h4>Description:</h4>
-                                    <div>{{description}}</div>
+                                    <div class="volunteer_express">{{description}}</div>
                                 </div>
                                 {{/description}}
                                 {{#when}}

--- a/resources/address/js/02_index.js
+++ b/resources/address/js/02_index.js
@@ -14,8 +14,7 @@ var render = function () {
     var function_button = $('#function_button').html(); $.each(data.function_button, function () { $('#function_button_cycle').append(Mustache.render(function_button, this)); });
     // var category = $('#category').html(); $.each(data.address_book_categories, function () { $('#address').append(Mustache.render(category, this));});
     $("#breadcrumbs").after(function() { return Mustache.render($(this).html(), data); });
-    var street_name = $('#street_name').html();
-    $.each(data.names_by_street, function() { $('#user_list').append(Mustache.render(street_name, this));});
+    var street_name = $('#street_name').html();$.each(data.street_name, function() { $('#user_list').append(Mustache.render(street_name, this));});
     // Global post render
     _post_render();
 


### PR DESCRIPTION
刚才push的内容---合并冲突问题
address页面中----点击“Click here to list by Street Name“后找不到街道渲染的那块---js中取数据有错误，正确的取出数据
Volunteer Needs页面中----Description中差一个class属性名---加上volunteer-express属性--解决溢出加省略号的问题
about us页面中---让li里的内容排列---给每个li加上width:100%属性值
memeber页面中---给右面的remove，make Admin默认input背景去掉---加一个background:transparent属性